### PR TITLE
refactor: modernize team section

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -140,16 +140,18 @@
               <div class="team-member">
                 <img src="img/wolfgang-cut.png" alt="DI Wolfgang Hillisch" class="team-photo">
                 <div class="member-info">
-                  <h3>DI Wolfgang Hillisch</h3>
+                  <div class="member-name">
+                    <h3>DI Wolfgang Hillisch</h3>
+                    <a href="https://www.linkedin.com/in/wolfgang-hillisch-b809332a/" target="_blank" rel="noopener noreferrer" class="linkedin-link" aria-label="LinkedIn Profile">
+                      <img src="img/li.png" alt="LinkedIn" class="linkedin-icon">
+                    </a>
+                  </div>
                   <p class="role">Founder & CEO</p>
                   <ul class="highlights">
                     <li><strong>Decades of experience</strong> in leading companies and driving transformation</li>
                     <li><strong>25 years</strong> in senior operational roles, including 12 years as Managing Director and CEO</li>
                     <li><strong>6 years</strong> experience as a consultant for Private Equity and Industrial sectors</li>
                   </ul>
-                  <a href="https://www.linkedin.com/in/wolfgang-hillisch-b809332a/" target="https://www.linkedin.com/in/wolfgang-hillisch-b809332a/" class="linkedin-link">
-                    <img src="img/li.png" alt="LinkedIn"> LinkedIn Profile
-                  </a>
                 </div>
               </div>
           
@@ -157,16 +159,18 @@
               <div class="team-member">
                 <img src="img/alex-cut.png" alt="Alexander Hillisch BSc" class="team-photo">
                 <div class="member-info">
-                  <h3>Alexander Hillisch BSc</h3>
+                  <div class="member-name">
+                    <h3>Alexander Hillisch BSc</h3>
+                    <a href="https://www.linkedin.com/in/alexander-hillisch-a9967a235/" target="_blank" rel="noopener noreferrer" class="linkedin-link" aria-label="LinkedIn Profile">
+                      <img src="img/li.png" alt="LinkedIn" class="linkedin-icon">
+                    </a>
+                  </div>
                   <p class="role">IT Consultant & AI Specialist</p>
                   <ul class="highlights">
                     <li><strong>Years of experience</strong> in IT consulting, with a focus on SAP process improvements and development</li>
                     <li><strong>Expertise</strong> in business analytics, improving operational efficiency and implementing innovative IT solutions</li>
                     <li><strong>Master’s student</strong> in Artificial Intelligence</li>
                   </ul>
-                  <a href="https://www.linkedin.com/in/alexander-hillisch-a9967a235/" target="https://www.linkedin.com/in/alexander-hillisch-a9967a235/" class="linkedin-link">
-                    <img src="img/li.png" alt="LinkedIn"> LinkedIn Profile
-                  </a>
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -148,16 +148,18 @@
                 <div class="team-member">
                   <img src="img/wolfgang-cut.png" alt="DI Wolfgang Hillisch" class="team-photo">
                   <div class="member-info">
-                    <h3>DI Wolfgang Hillisch</h3>
+                    <div class="member-name">
+                      <h3>DI Wolfgang Hillisch</h3>
+                      <a href="https://www.linkedin.com/in/wolfgang-hillisch-b809332a/" target="_blank" rel="noopener noreferrer" class="linkedin-link" aria-label="LinkedIn-Profil">
+                        <img src="img/li.png" alt="LinkedIn" class="linkedin-icon">
+                      </a>
+                    </div>
                     <p class="role">Gründer & Geschäftsführer</p>
                     <ul class="highlights">
                       <li><strong>Jahrzehntelange Erfahrung</strong> in Leitung von Unternehmen sowie deren Transformation</li>
                       <li><strong>25 Jahre</strong> in Führungspositionen, darunter 12 Jahre als Geschäftsführer und CEO</li>
                       <li><strong>6 Jahre</strong> Erfahrung als Berater für Private Equity und Industrie</li>
                     </ul>
-                    <a href="https://www.linkedin.com/in/wolfgang-hillisch-b809332a/" target="https://www.linkedin.com/in/wolfgang-hillisch-b809332a/" class="linkedin-link">
-                      <img src="img/li.png" alt="LinkedIn"> LinkedIn-Profil
-                    </a>
                   </div>
                 </div>
           
@@ -165,16 +167,18 @@
                 <div class="team-member">
                   <img src="img/alex-cut.png" alt="Alexander Hillisch BSc" class="team-photo">
                   <div class="member-info">
-                    <h3>Alexander Hillisch BSc</h3>
+                    <div class="member-name">
+                      <h3>Alexander Hillisch BSc</h3>
+                      <a href="https://www.linkedin.com/in/alexander-hillisch-a9967a235/" target="_blank" rel="noopener noreferrer" class="linkedin-link" aria-label="LinkedIn-Profil">
+                        <img src="img/li.png" alt="LinkedIn" class="linkedin-icon">
+                      </a>
+                    </div>
                     <p class="role">IT-Berater & KI-Spezialist</p>
                     <ul class="highlights">
                       <li><strong>Mehrere Jahre Erfahrung</strong> in der IT-Beratung mit Fokus auf SAP-Prozessoptimierung und Entwicklung</li>
                       <li><strong>Expertise</strong> in Business Analytics, Effizienzsteigerung und innovativen IT-Lösungen</li>
                       <li><strong>Master-Student</strong> im Bereich Künstliche Intelligenz</li>
                     </ul>
-                    <a href="https://www.linkedin.com/in/alexander-hillisch-a9967a235/" target="https://www.linkedin.com/in/alexander-hillisch-a9967a235/" class="linkedin-link">
-                      <img src="img/li.png" alt="LinkedIn"> LinkedIn-Profil
-                    </a>
                   </div>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -325,6 +325,35 @@ body.blue-bg .language-toggle2 {
   margin-bottom: .5rem;
 }
 
+.member-name h3 {
+  margin: 0;
+}
+
+.role {
+  font-weight: 600;
+  color: var(--color-accent);
+  margin-bottom: .75rem;
+}
+
+.highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+.highlights li {
+  position: relative;
+  padding-left: 1.5rem;
+  margin-bottom: .5rem;
+}
+
+.highlights li::before {
+  content: "\2713";
+  position: absolute;
+  left: 0;
+  color: var(--color-accent);
+}
+
 .member-info a {
   color: var(--color-accent);
   text-decoration: none;
@@ -337,6 +366,7 @@ body.blue-bg .language-toggle2 {
 
 .linkedin-link {
   display: inline-flex;
+  align-items: center;
   margin-top: 0;
 }
 


### PR DESCRIPTION
## Summary
- Modernized "Unser Team" and "Our Team" sections with LinkedIn icons placed next to member names
- Added role and highlight list styling for cleaner presentation
- Improved link semantics and accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6204ee5a4832c89a83e6a13a95989