### PR TITLE
Align language flags next to burger menu on legal notice pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -92,10 +92,6 @@ body.blue-bg .navbar-container {
 
 .language-toggle2 {
   display: flex;
-  gap: .5rem;
-}
-
-body.blue-bg .language-toggle2 {
   align-items: center;
   gap: 10px;
   margin-left: auto;


### PR DESCRIPTION
## Summary
- Ensure the language switcher flags align next to the burger icon by moving layout styles into the `.language-toggle2` class.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a622d3dc94832cb6d3bee256f418dd