### PR TITLE
Remove What We Do headings from index pages

### DIFF
--- a/index-en.html
+++ b/index-en.html
@@ -84,7 +84,6 @@
     <main>
         <section id="what-we-do">
             <!-- Image and Slogan Section -->
-            <h2>What We Do</h2>
             <div class="content">
                 <div class="image-content">
                     <div class="hero-image-container">

--- a/index.html
+++ b/index.html
@@ -97,7 +97,6 @@
     <main>
         <section id="what-we-do">
             <!-- Bild- und Slogan-Bereich -->
-            <h2>Was wir tun</h2>
             <div class="content">
                 <div class="image-content">
                     <div class="hero-image-container">


### PR DESCRIPTION
## Summary
- Drop "What We Do" and "Was wir tun" section headings from index pages so hero section starts with content immediately.

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a622f0cd84832c8a6a2a04d1e8e398