### PR TITLE
Fix services layout on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -227,8 +227,14 @@ body.blue-bg .language-toggle2 {
 .card-container {
   display: grid;
   gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: 1fr;
   margin-top: 2rem;
+}
+
+@media (min-width: 900px) {
+  .card-container {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .card {


### PR DESCRIPTION
## Summary
- avoid two-column layout for service cards on mobile
- show three cards in a row only on large screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a623a6d13c832c80923967df5eb273