### PR TITLE
Make contact section responsive on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -456,6 +456,17 @@ body.blue-bg .navbar-container {
   .language-toggle2 {
     order: 2;
   }
+  .contact-wrapper {
+    flex-direction: column;
+    align-items: center;
+  }
+  .contact-photo {
+    width: 100%;
+    text-align: center;
+  }
+  .contact-details {
+    width: 100%;
+  }
 }
 .contact-cta {
   text-align: center;


### PR DESCRIPTION
## Summary
- Stack contact photo above details on narrow viewports
- Ensure contact photo and details span full width on mobile

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a624c83dd4832c8178687085417e39