### PR TITLE
Ensure contact image matches details height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -395,16 +395,20 @@ body.blue-bg .navbar-container {
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
-  align-items: center;
+  align-items: stretch;
 }
 
 .contact-photo {
   flex: 1 1 250px;
+  display: flex;
 }
 
 .founder-photo {
   border-radius: .5rem;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .contact-details {
@@ -461,10 +465,14 @@ body.blue-bg .navbar-container {
   }
   .contact-photo {
     width: 100%;
-    text-align: center;
+    justify-content: center;
+    align-items: center;
   }
   .contact-details {
     width: 100%;
+  }
+  .founder-photo {
+    height: auto;
   }
 }
 .contact-cta {


### PR DESCRIPTION
## Summary
- Stretch the contact image to match the height of the contact details, ensuring consistent sizing.
- Center and stack the image above details on smaller screens when equal height isn't possible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a625e2e79c832c80e6407faee8239d