### PR TITLE
Equalize contact details and image height

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,7 @@
   --color-dark: #1e1e1e;
   --max-width: 1200px;
   --font-family: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  --contact-detail-height: 60px;
 }
 
 *,
@@ -395,22 +396,29 @@ body.blue-bg .navbar-container {
   display: flex;
   flex-wrap: wrap;
   gap: 2rem;
-  align-items: center;
+  align-items: stretch;
 }
 
 .contact-photo {
   flex: 1 1 250px;
+  display: flex;
+  height: calc(var(--contact-detail-height) * 4 + 0.75rem * 3);
 }
 
 .founder-photo {
   border-radius: .5rem;
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .contact-details {
   flex: 2 1 300px;
-  display: grid;
-  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: calc(var(--contact-detail-height) * 4 + 0.75rem * 3);
 }
 
 .contact-detail {
@@ -419,9 +427,8 @@ body.blue-bg .navbar-container {
   gap: 1rem;
   background: #fff;
   color: var(--color-dark);
-  padding: 1rem;
-  /* Ensure all contact detail boxes share the same height */
-  min-height: 64px;
+  padding: 0.75rem;
+  height: var(--contact-detail-height);
   border-radius: .5rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
@@ -461,10 +468,16 @@ body.blue-bg .navbar-container {
   }
   .contact-photo {
     width: 100%;
-    text-align: center;
+    justify-content: center;
+    align-items: center;
+    height: auto;
   }
   .contact-details {
     width: 100%;
+    height: auto;
+  }
+  .founder-photo {
+    height: auto;
   }
 }
 .contact-cta {


### PR DESCRIPTION
## Summary
- Add `--contact-detail-height` variable and use it to size all contact detail boxes uniformly
- Sync founder photo height with the stacked contact details and reduce padding for a more compact layout
- Reset heights on small screens so the photo stacks above the details without distortion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a625e2e79c832c80e6407faee8239d