### PR TITLE
Fix burger menu alignment on mobile

### DIFF
--- a/case.css
+++ b/case.css
@@ -125,3 +125,16 @@ body {
     object-fit: cover; /* Hält die richtige Flaggenproportion */
     display: block; /* Stellt sicher, dass die Flags inline bleiben */
 }
+
+@media (max-width: 768px) {
+    .language-toggle2 {
+        order: 1;
+        margin-left: 0;
+        padding-right: 0;
+    }
+
+    .burger-menu {
+        margin-left: auto;
+        order: 2;
+    }
+}

--- a/case0.css
+++ b/case0.css
@@ -109,3 +109,16 @@
     display: block; /* Stellt sicher, dass die Flags inline bleiben */
 }
 
+@media (max-width: 768px) {
+    .language-toggle2 {
+        order: 1;
+        margin-left: 0;
+        padding-right: 0;
+    }
+
+    .burger-menu {
+        margin-left: auto;
+        order: 2;
+    }
+}
+

--- a/styles.css
+++ b/styles.css
@@ -456,12 +456,16 @@ body.blue-bg .navbar-container {
 @media (max-width: 768px) {
   .burger-menu {
     display: flex;
+    margin-left: auto;
+    order: 2;
   }
   .desktop-nav {
     display: none;
   }
   .language-toggle2 {
-    order: 2;
+    order: 1;
+    margin-left: 0;
+    padding-right: 0;
   }
   .contact-wrapper {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure mobile burger menu aligns to the right by adjusting flex order and margins
- apply the same mobile override to case study stylesheets for consistent behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62ae60e14832cb5260836489e0767