### PR TITLE
Fix burger menu alignment on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -465,7 +465,7 @@ body.blue-bg .navbar-container {
     display: none;
   }
   .language-toggle2 {
-    order: 2;
+    order: 0;
   }
   .contact-wrapper {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- ensure burger icon remains right-aligned on mobile by resetting language toggle order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62e531634832c887f660f3cc57f5a