### PR TITLE
Improve contact alignment for responsive layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -53,4 +53,18 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   }
+
+  const contactTexts = document.querySelectorAll('.contact-detail p');
+  function updateContactAlignment() {
+    contactTexts.forEach(p => {
+      const lineHeight = parseFloat(getComputedStyle(p).lineHeight);
+      if (p.offsetHeight > lineHeight * 1.2) {
+        p.style.textAlign = 'left';
+      } else {
+        p.style.textAlign = 'center';
+      }
+    });
+  }
+  updateContactAlignment();
+  window.addEventListener('resize', updateContactAlignment);
 });

--- a/styles.css
+++ b/styles.css
@@ -432,7 +432,7 @@ body.blue-bg .navbar-container {
   height: var(--contact-detail-height);
   border-radius: .5rem;
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-  text-align: left;
+  text-align: center;
 }
 
 .contact-detail a {
@@ -441,7 +441,7 @@ body.blue-bg .navbar-container {
 
 .contact-detail p {
   margin: 0;
-  text-align: left;
+  text-align: center;
 }
 
 .contact-icon {
@@ -469,9 +469,13 @@ body.blue-bg .navbar-container {
   .language-toggle2 {
     order: 0;
   }
+  .contact-section {
+    padding: 1rem 0.5rem;
+  }
   .contact-wrapper {
     flex-direction: column;
     align-items: center;
+    gap: 1rem;
   }
   .contact-photo {
     width: 100%;
@@ -482,6 +486,10 @@ body.blue-bg .navbar-container {
   .contact-details {
     width: 100%;
     height: auto;
+    gap: 0.5rem;
+  }
+  .contact-detail {
+    padding: 0.5rem;
   }
   .founder-photo {
     height: auto;


### PR DESCRIPTION
## Summary
- Center single-line contact details and shift to left alignment when wrapping occurs via script
- Reduce contact section padding and spacing on small screens for better fit

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a633b00e78832cbf0d793de95f1abc